### PR TITLE
Fix examples include to absolute path

### DIFF
--- a/examples/example-ant/moses-ant-hillclimbing.cc
+++ b/examples/example-ant/moses-ant-hillclimbing.cc
@@ -34,12 +34,12 @@
 #include <moses/comboreduct/ant_combo_vocabulary/ant_combo_vocabulary.h>
 #include <moses/comboreduct/reduct/reduct.h>
 
-#include "../deme/deme_expander.h"
-#include "../metapopulation/metapopulation.h"
-#include "../moses/moses_main.h"
-#include "../optimization/optimization.h"
-#include "../scoring/scoring_base.h"
-#include "../scoring/behave_cscore.h"
+#include <moses/moses/deme/deme_expander.h>
+#include <moses/moses/metapopulation/metapopulation.h>
+#include <moses/moses/moses/moses_main.h>
+#include <moses/moses/optimization/optimization.h>
+#include <moses/moses/scoring/scoring_base.h>
+#include <moses/moses/scoring/behave_cscore.h>
 #include "ant_scoring.h"
 
 

--- a/examples/example-progs/moses-ann-pole1.cc
+++ b/examples/example-progs/moses-ann-pole1.cc
@@ -1,4 +1,4 @@
-/** moses-ann-pole1.cc --- 
+/** moses-ann-pole1.cc ---
  *
  * Copyright (C) 2010-2011 OpenCog Foundation
  *
@@ -8,12 +8,12 @@
  * it under the terms of the GNU Affero General Public License v3 as
  * published by the Free Software Foundation and including the exceptions
  * at http://opencog.org/wiki/Licenses
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program; if not, write to:
  * Free Software Foundation, Inc.,
@@ -24,12 +24,12 @@
 #include <opencog/util/Logger.h>
 #include <moses/comboreduct/interpreter/eval.h>
 
-#include "../deme/deme_expander.h"
-#include "../metapopulation/metapopulation.h"
-#include "../moses/moses_main.h"
-#include "../representation/representation.h"
-#include "../optimization/optimization.h"
-#include "../scoring/scoring_base.h"
+#include <moses/moses/deme/deme_expander.h>
+#include <moses/moses/metapopulation/metapopulation.h>
+#include <moses/moses/moses/moses_main.h>
+#include <moses/moses/representation/representation.h>
+#include <moses/moses/optimization/optimization.h>
+#include <moses/moses/scoring/scoring_base.h>
 
 #include "pole_scoring.h"
 
@@ -54,7 +54,7 @@ int main(int argc, char** argv)
         //    throw "foo";
         // int max_evals=lexical_cast<int>(argv[1]);
         seed=lexical_cast<int>(argv[2]);
-        
+
         set_stepsize(lexical_cast<double>(argv[3]));
         set_expansion(lexical_cast<double>(argv[4]));
         set_depth(lexical_cast<int>(argv[5]));
@@ -66,22 +66,22 @@ int main(int argc, char** argv)
         cerr << "usage: " << argv[0] << " maxevals seed" << endl;
         exit(1);
     }
-    
+
     // Read seed tree in from stdin.
     combo_tree tr;
-    cin >> tr; 
+    cin >> tr;
 
     randGen().seed(seed);
 
     type_tree tt(id::lambda_type);
     tt.append_children(tt.begin(), id::ann_type, 1);
-    
+
     const reduct::rule* si = &(ann_reduction());
     if(!reduce)
         si = &(clean_reduction());
 
     //SINGLE MARKOVIAN POLE TASK
-    ann_pole_bscore p_bscore; 
+    ann_pole_bscore p_bscore;
     behave_cscore cscorer(p_bscore);
 
     univariate_optimization optim_algo;
@@ -93,17 +93,17 @@ int main(int argc, char** argv)
     run_moses(metapop_pole, dex, pa, st);
 
     //change best tree into ANN
-    tree_transform trans; 
+    tree_transform trans;
     combo_tree best = metapop_pole.best_tree();
     ann bestnet = trans.decodify_tree(best);
-   
+
     //write out the best network
-    cout << "Best network: " << endl; 
+    cout << "Best network: " << endl;
     cout << &bestnet << endl;
 
     //write out in dot format
     bestnet.write_dot("best_nn.dot");
-    
+
     //for parameter sweep
     cout << metapop_pole.best_score() << endl;
 }

--- a/examples/example-progs/moses-ann-pole2-hillclimbing.cc
+++ b/examples/example-progs/moses-ann-pole2-hillclimbing.cc
@@ -5,12 +5,12 @@
 #include <moses/comboreduct/interpreter/eval.h>
 
 
-#include "../deme/deme_expander.h"
-#include "../metapopulation/metapopulation.h"
+#include <moses/moses/deme/deme_expander.h>
+#include <moses/moses/metapopulation/metapopulation.h>
 
-#include "../moses/moses_main.h"
-#include "../optimization/optimization.h"
-#include "../scoring/scoring_base.h"
+#include <moses/moses/moses/moses_main.h>
+#include <moses/moses/optimization/optimization.h>
+#include <moses/moses/scoring/scoring_base.h>
 
 #include "pole_scoring.h"
 
@@ -29,7 +29,7 @@ int main(int argc, char** argv)
     logger().setPrintErrorLevelStdout();
 
     combo_tree tr;
-    cin >> tr; 
+    cin >> tr;
 
     tree_transform trans;
     ann nn = trans.decodify_tree(tr);
@@ -57,10 +57,10 @@ int main(int argc, char** argv)
 
     combo_tree best = metapop_pole2.best_tree();
     ann bestnet = trans.decodify_tree(best);
-    
+
     cout << "Best network: " << endl;
     cout << &bestnet << endl;
-    bestnet.write_dot("best_nn.dot");    
+    bestnet.write_dot("best_nn.dot");
 
     //for parameter sweet
     cout << metapop_pole2.best_score() << endl;

--- a/examples/example-progs/moses-ann-pole2.cc
+++ b/examples/example-progs/moses-ann-pole2.cc
@@ -1,4 +1,4 @@
-/** moses-ann-pole2.cc --- 
+/** moses-ann-pole2.cc ---
  *
  * Copyright (C) 2010-2011 OpenCog Foundation
  *
@@ -8,12 +8,12 @@
  * modify it under the terms of the GNU General Public License as
  * published by the Free Software Foundation; either version 2, or (at
  * your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; see the file COPYING.  If not, write to
  * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
@@ -26,13 +26,13 @@
 
 #include <moses/comboreduct/interpreter/eval.h>
 
-#include "../deme/deme_expander.h"
-#include "../metapopulation/metapopulation.h"
+#include <moses/moses/deme/deme_expander.h>
+#include <moses/moses/metapopulation/metapopulation.h>
 
-#include "../representation/representation.h"
-#include "../optimization/optimization.h"
-#include "../moses/moses_main.h"
-#include "../scoring/scoring_base.h"
+#include <moses/moses/representation/representation.h>
+#include <moses/moses/optimization/optimization.h>
+#include <moses/moses/moses/moses_main.h>
+#include <moses/moses/scoring/scoring_base.h>
 
 #include "pole_scoring.h"
 
@@ -66,10 +66,10 @@ int main(int argc, char** argv)
         cerr << "usage: " << argv[0] << " maxevals seed" << endl;
         exit(1);
     }
-    
+
     // Read in seed tree.
     combo_tree tr;
-    cin >> tr; 
+    cin >> tr;
 
     randGen().seed(seed);
 
@@ -80,8 +80,8 @@ int main(int argc, char** argv)
     const reduct::rule* si = &(ann_reduction());
     if (!reduce)
         si = &(clean_reduction());
-    
-    ann_pole2_bscore p2_bscore; 
+
+    ann_pole2_bscore p2_bscore;
     behave_cscore cscorer(p2_bscore);
 
     univariate_optimization univ;
@@ -93,15 +93,15 @@ int main(int argc, char** argv)
     run_moses(metapop_pole2, dex, pa, st);
 
     //change best combo tree back into ANN
-    tree_transform trans; 
+    tree_transform trans;
     combo_tree best = metapop_pole2.best_tree();
     ann bestnet = trans.decodify_tree(best);
-    
+
     //show best network
     cout << "Best network: " << endl;
     cout << &bestnet << endl;
     //write out in dot format
-    bestnet.write_dot("best_nn.dot"); 
+    bestnet.write_dot("best_nn.dot");
 
     //for parameter sweet
     cout << metapop_pole2.best_score() << endl;

--- a/examples/example-progs/moses-ann-pole2nv.cc
+++ b/examples/example-progs/moses-ann-pole2nv.cc
@@ -4,13 +4,13 @@
 #include <opencog/util/Logger.h>
 #include <moses/comboreduct/interpreter/eval.h>
 
-#include "../deme/deme_expander.h"
-#include "../metapopulation/metapopulation.h"
+#include <moses/moses/deme/deme_expander.h>
+#include <moses/moses/metapopulation/metapopulation.h>
 
-#include "../representation/representation.h"
-#include "../moses/moses_main.h"
-#include "../optimization/optimization.h"
-#include "../scoring/scoring_base.h"
+#include <moses/moses/representation/representation.h>
+#include <moses/moses/moses/moses_main.h>
+#include <moses/moses/optimization/optimization.h>
+#include <moses/moses/scoring/scoring_base.h>
 
 #include "pole_scoring.h"
 
@@ -44,10 +44,10 @@ int main(int argc, char** argv)
         cerr << "usage: " << argv[0] << " maxevals seed" << endl;
         exit(1);
     }
-    
+
     //read in seed tree
     combo_tree tr;
-    cin >> tr; 
+    cin >> tr;
 
     randGen().seed(seed);
 
@@ -58,8 +58,8 @@ int main(int argc, char** argv)
     const reduct::rule* si = &(ann_reduction());
     if(!reduce)
         si = &(clean_reduction());
-    
-    ann_pole2nv_bscore p2_bscore; 
+
+    ann_pole2nv_bscore p2_bscore;
     behave_cscore cscorer(p2_bscore);
 
     univariate_optimization univ;
@@ -73,22 +73,22 @@ int main(int argc, char** argv)
     run_moses(metapop_pole2, dex, moses_param, st);
 
     //change best combo tree back into ANN
-    tree_transform trans; 
+    tree_transform trans;
     combo_tree best = metapop_pole2.best_tree();
     ann bestnet = trans.decodify_tree(best);
-    
+
     //show best network
     cout << "Best network: " << endl;
     cout << &bestnet << endl;
     //write out in dot format
-    bestnet.write_dot("best_nn.dot"); 
+    bestnet.write_dot("best_nn.dot");
 
     CartPole *the_cart;
     the_cart = new CartPole(true,false);
     the_cart->nmarkov_long=true;
     the_cart->generalization_test=false;
     double fitness = the_cart->evalNet(&bestnet);
-    delete the_cart; 
+    delete the_cart;
     //for parameter sweep
     cout << fitness << endl;
 }

--- a/examples/example-progs/moses-ann-xor.cc
+++ b/examples/example-progs/moses-ann-xor.cc
@@ -6,13 +6,13 @@
 
 #include <moses/comboreduct/interpreter/eval.h>
 
-#include "../deme/deme_expander.h"
-#include "../metapopulation/metapopulation.h"
+#include <moses/moses/deme/deme_expander.h>
+#include <moses/moses/metapopulation/metapopulation.h>
 
-#include "../moses/moses_main.h"
-#include "../scoring/scoring_base.h"
-#include "../optimization/optimization.h"
-#include "../representation/representation.h"
+#include <moses/moses/moses/moses_main.h>
+#include <moses/moses/scoring/scoring_base.h>
+#include <moses/moses/optimization/optimization.h>
+#include <moses/moses/representation/representation.h>
 
 #include "ann_xor_scoring.h"
 
@@ -46,12 +46,12 @@ int main(int argc, char** argv)
         cerr << "usage: " << argv[0] << " maxevals seed" << endl;
         exit(1);
     }
-    
+
     // read in the seed combo tree from stdin
     // a default seed is provided in file xor_tree
     combo_tree tr;
-    cin >> tr; 
-    
+    cin >> tr;
+
     randGen().seed(seed);
 
     // this will let representation building know that we are dealing
@@ -80,32 +80,32 @@ int main(int argc, char** argv)
     run_moses(metapop, dex, moses_param, st);
 
     //transform the best combo tree into an ANN
-    tree_transform trans; 
+    tree_transform trans;
     combo_tree best = metapop.best_tree();
     ann bestnet = trans.decodify_tree(best);
-    
-    
+
+
     //look at xor outputs
-    double inputs[4][3] = { {0.0, 0.0, 1.0}, 
-                            {0.0, 1.0, 1.0}, 
+    double inputs[4][3] = { {0.0, 0.0, 1.0},
+                            {0.0, 1.0, 1.0},
                             {1.0, 0.0, 1.0},
                             {1.0, 1.0, 1.0}};
-    
+
     int depth = bestnet.feedforward_depth();
-    
+
     for (int pattern = 0;pattern < 4;++pattern) {
         bestnet.load_inputs(inputs[pattern]);
         for (int x = 0;x < depth;++x)
             bestnet.propagate();
         cout << "Input [ " << inputs[pattern][0] << " " << inputs[pattern][1] << " ] : Output " << bestnet.outputs[0]->activation << endl;
-    
+
     }
-   
+
     //save the best network (can be viewed in any dot viewer)
     cout << "Best network: " << endl;
     cout << &bestnet << endl;
     bestnet.write_dot("best_nn.dot");
-       
+
     //write out the best score (to be used in parameter sweep)
     cout << metapop.best_score() << endl;
 }

--- a/examples/example-progs/moses-perf.cc
+++ b/examples/example-progs/moses-perf.cc
@@ -16,7 +16,7 @@
 #include <math.h>
 #include <sstream>
 #include <sys/time.h>
-#include "../main/moses_exec.h"
+#include <moses/moses/main/moses_exec.h>
 
 using namespace std;
 using namespace opencog::moses;
@@ -96,7 +96,7 @@ void measure(vector<string> arguments)
             double max_speed = 1.0 / (1.0-parallel);
             printf("speedup = %f parallelizable fraction = %f max speedup = %f\n",
                 speedup, parallel, max_speed);
-                
+
         }
 #endif
         fflush (stdout);

--- a/examples/example-progs/scoring_functions.h
+++ b/examples/example-progs/scoring_functions.h
@@ -32,7 +32,7 @@
 #include <opencog/util/RandGen.h>
 #include <opencog/util/oc_assert.h>
 
-#include "../representation/field_set.h"
+#include <moses/moses/representation/field_set.h>
 
 using namespace opencog;
 using namespace moses;

--- a/moses/moses/CMakeLists.txt
+++ b/moses/moses/CMakeLists.txt
@@ -56,6 +56,7 @@ ADD_LIBRARY (moses SHARED
 	optimization/optimization
 	optimization/star-anneal
 	optimization/univariate
+    optimization/particle-swarm
 
 	representation/build_knobs
 	representation/field_set

--- a/moses/moses/moses/moses_main.h
+++ b/moses/moses/moses/moses_main.h
@@ -36,6 +36,7 @@
 #include "../optimization/hill-climbing.h"
 #include "../optimization/star-anneal.h"
 #include "../optimization/univariate.h"
+#include "../optimization/particle-swarm.h"
 #include "../scoring/behave_cscore.h"
 #include "../scoring/ss_bscore.h"
 #include "distributed_moses.h"
@@ -277,6 +278,9 @@ void metapop_moses_results_b(const std::vector<combo_tree>& bases,
     }
     else if (opt_params.opt_algo == un) { // univariate
         optimizer = new univariate_optimization(opt_params);
+    }
+    else if (opt_params.opt_algo == ps) { // particle swarm
+        optimizer = new particle_swarm(opt_params, hc_params);
     }
     else {
         std::cerr << "Unknown optimization algo " << opt_params.opt_algo

--- a/moses/moses/optimization/CMakeLists.txt
+++ b/moses/moses/optimization/CMakeLists.txt
@@ -4,6 +4,7 @@ INSTALL(FILES
 	optimization.h
 	star-anneal.h
 	univariate.h
+	particle-swarm.h
 
 	DESTINATION
 

--- a/moses/moses/optimization/optimization.h
+++ b/moses/moses/optimization/optimization.h
@@ -66,6 +66,7 @@ double information_theoretic_bits(const field_set& fs);
 static const std::string un("un"); // univariate
 static const std::string sa("sa"); // star-shaped search
 static const std::string hc("hc"); // local search
+static const std::string ps("ps"); // particle swarm
 
 // Parameters used mostly for EDA algorithms but also possibly by
 // other algo
@@ -174,7 +175,7 @@ struct optimizer_base : optim_stats
 {
     optimizer_base(const optim_parameters& op = optim_parameters())
         : opt_params(op) {}
-    
+
     virtual void operator()(deme_t& deme,
                             const iscorer_base& iscorer,
                             unsigned max_evals,

--- a/moses/moses/optimization/particle-swarm.cc
+++ b/moses/moses/optimization/particle-swarm.cc
@@ -1,0 +1,183 @@
+/*
+ * moses/moses/optimization/particle-swarm.cc
+ *
+ * Copyright (C) 2002-2008 Novamente LLC
+ * Copyright (C) 2012 Poulin Holdings LLC
+ * All Rights Reserved
+ *
+ * Written by Arley Ristar
+ *            Nil Geisweiller
+ *            Linas Vepstas
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <math.h>   // for sqrtf, cbrtf
+
+#include <boost/algorithm/minmax_element.hpp>
+
+#include <opencog/util/oc_omp.h>
+
+#include "../moses/neighborhood_sampling.h"
+
+#include "particle-swarm.h"
+
+namespace opencog { namespace moses {
+
+
+////////////////////
+// Particle Swarm //
+////////////////////
+
+void particle_swarm::operator()(deme_t& deme,
+                               const instance& init_inst,
+                               const iscorer_base& iscorer,
+                               unsigned max_evals,
+                               time_t max_time)
+{
+    logger().debug("Enter PSO...");
+// TODO: basically everything.
+    optimizer_base* _opthc =
+        new hill_climbing(opt_params, ps_params);
+    optimizer_base& _hc = *_opthc;
+    _hc(deme, iscorer, max_evals, max_time);
+#define ACCEPTABLE_SIZE 5000
+#define ACCEPTABLE_RAM_FRACTION 0.5
+
+} // ~operator
+
+// TODO: verify comments and code
+/// Shrink the deme, by removing all instances with score less than
+/// 'cutoff'.  This is implemented with in-place deletion of elements
+/// from a vector, with at least a token attempt to delete contigous
+/// regions of low scores, in one go.  It is possible that a faster
+/// algorithm would be to sort first, and then delete the tail-end of
+/// the vector.  But this ixsn't know ... XXX experiment with this!?
+/// ... err, but right now, trimming takes a small fraction of a second,
+/// so there is no rush to fis this.
+size_t particle_swarm::resize_by_score(deme_t& deme, score_t cutoff)
+{
+    size_t ndeleted = 0;
+    while (true) {
+         auto first = deme.end();
+         auto last = deme.end();
+         size_t contig = 0;
+         for (auto it = deme.begin(); it != deme.end(); it++) {
+             score_t iscore = it->second.get_penalized_score();
+             if (iscore <= cutoff) {
+                 if (0 == contig) first = it;
+                 last = it;
+                 contig ++;
+             } else {
+                 if (0 < contig)
+                     break;
+             }
+         }
+
+         if (0 == contig)
+             break;
+
+         if (last != deme.end()) last++;
+         deme.erase(first, last);
+         ndeleted += contig;
+
+         // Keep around at least 20 instances; useful for cross-over.
+#define MIN_TO_KEEP 20
+         if (deme.size() < MIN_TO_KEEP)
+             break;
+    }
+    logger().debug() << "Trimmed "
+            << ndeleted << " low scoring instances.";
+    return deme.size();
+}
+
+/// Keep the size of the deme at a managable level.
+/// Large populations can easily blow out the RAM on a machine,
+/// so we want to keep it at some reasonably trim level.
+//
+bool particle_swarm::resize_deme(deme_t& deme, score_t best_score)
+{
+    bool did_resize =  false;
+    // Lets see how many we might be able to trounce.
+    score_t cutoff = best_score - ps_params.score_range;
+    size_t bad_score_cnt = 0;
+
+    // To find the number of bad scores, we have to look
+    // at the *whole* deme.
+    for (const deme_inst_t& si : deme) {
+        score_t iscore = si.second.get_penalized_score();
+        if (iscore <=  cutoff)
+            bad_score_cnt++;
+    }
+
+
+    // To avoid wasting cpu time pointlessly, don't bother with
+    // population size management if we don't get any bang out
+    // of it.
+#define DONT_BOTHER_SIZE 500
+    uint64_t usage = _instance_bytes * deme.size();
+
+    if ((DONT_BOTHER_SIZE < bad_score_cnt) or
+        (ACCEPTABLE_RAM_FRACTION * _total_RAM_bytes < usage))
+    {
+
+        logger().debug() << "Will trim " << bad_score_cnt
+            << " low scoring instances out of " << deme.size();
+        resize_by_score(deme, cutoff);
+        did_resize = true;
+    }
+
+    // Are we still too large? Whack more, if needed.
+    // We want to whack only the worst scorerers, and thus
+    // a partial sort up front.
+    if ((ps_params.max_allowed_instances < deme.size()) or
+        (ACCEPTABLE_RAM_FRACTION * _total_RAM_bytes < usage))
+    {
+        std::partial_sort(deme.begin(),
+                          next(deme.begin(), ps_params.max_allowed_instances),
+                          deme.end(),
+                          std::greater<deme_inst_t>());
+
+        deme.erase(next(deme.begin(), ps_params.max_allowed_instances),
+                   deme.end());
+        did_resize = true;
+    }
+    return did_resize;
+}
+
+void particle_swarm::log_stats_legend()
+{
+    logger().info() << ps_params.prefix_stat_deme << "Hill: # "   /* Legend for graph stats */
+        "demeID\t"
+        "iteration\t"
+        "total_steps\t"
+        "total_evals\t"
+        "microseconds\t"
+        "new_instances\t"
+        "num_instances\t"
+        "inst_RAM\t"
+        "num_evals\t"
+        "has_improved\t"
+        "best_weighted_score\t"
+        "delta_weighted\t"
+        "best_raw\t"
+        "delta_raw\t"
+        "complexity";
+}
+
+} // ~namespace moses
+} // ~namespace opencog
+

--- a/moses/moses/optimization/particle-swarm.h
+++ b/moses/moses/optimization/particle-swarm.h
@@ -1,0 +1,131 @@
+/*
+ * moses/moses/optimization/particle-swarm.h
+ *
+ * Copyright (C) 2002-2008 Novamente LLC
+ * Copyright (C) 2012 Poulin Holdings
+ * All Rights Reserved
+ *
+ * Written by Arley Ristar
+ *            Nil Geisweiller
+ *            Linas Vepstas
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#ifndef _MOSES_PARTICLE_SWARM_H
+#define _MOSES_PARTICLE_SWARM_H
+
+#include <opencog/util/oc_assert.h>
+
+#include "../representation/instance_set.h"
+#include "optimization.h"
+#include "hill-climbing.h"
+
+namespace opencog { namespace moses {
+
+/// Hill-climbing paramters
+struct ps_parameters
+{
+     // TODO: pso paramters
+
+
+    // Range of scores for which to keep instances.  This *should* be
+    // set to the value given by metapopulation::useful_score_range().
+    // XXX TODO make sure this value is appropriately updated.
+    //
+    // The range of scores is used to keep the size of the deme in check.
+    // The issue is that, for large feature sets, a large number of knobs
+    // get created, which means that instances are huge.  It is easy to
+    // end up with demes in the tens-of-gigabytes in size, and that's bad,
+    // especially when most of the instances have terrible scores.
+    score_t score_range;
+
+    // Maximum allowed size of the deme.
+    // This is used to keep the size of the deme in check.
+    // The issue is that, for large feature sets, a large number of knobs
+    // get created, which means that instances are huge.  It is easy to
+    // end up with demes in the tens-of-gigabytes in size, and that's bad.
+    size_t max_allowed_instances;
+
+    // Flag to allow resizing the deme to keep memory usage under
+    // control. Note, however, since it depends on the size of the
+    // installed RAM, that two different runs of MOSES on two different
+    // machines but otheriwse identical inputs and parameters, may not
+    // behave identically to one-another.
+    bool resize_to_fit_ram;
+
+    // Deme stat name. String to indicate that TAB seperated deme
+    // statistics are logged. By default 'Demes'.
+    std::string prefix_stat_deme;
+};
+
+// TODO: pso description
+// TODO: code pso, hill_climbing for now
+struct particle_swarm : optimizer_base
+{
+    particle_swarm(const optim_parameters& op = optim_parameters(),
+            const hc_parameters& ps = hc_parameters()) //const hc_parameters& ps = ps_parameters())
+        : optimizer_base(op), ps_params(ps), _total_RAM_bytes(getTotalRAM())
+    {}
+
+protected:
+    // log legend for graph stats
+    void log_stats_legend();
+
+    bool resize_deme(deme_t& deme, score_t score_cutoff);
+    size_t resize_by_score(deme_t& deme, score_t score_cutoff);
+
+public:
+    /**
+     * Perform search of the local neighborhood of an instance.  The
+     * search is exhaustive if the local neighborhood is small; else
+     * the local neighborhood is randomly sampled.
+     *
+     * @param deme      Where to store the candidates searched. The deme
+     *                  is assumed to be empty.  If it is not empty, it
+     *                  will be overwritten.
+     * @prama init_inst Start the seach from this instance.
+     * @param iscorer   the Scoring function.
+     * @param max_evals The maximum number of evaluations to perform.
+     */
+    void operator()(deme_t& deme,
+                    const instance& init_inst,
+                    const iscorer_base& iscorer,
+                    unsigned max_evals,
+                    time_t max_time);
+
+    // Like above but assumes that init_inst is null (backward compatibility)
+    // XXX In fact, all of the current code uses this entry point, no one
+    // bothers to supply an initial instance.
+    void operator()(deme_t& deme,
+                    const iscorer_base& iscorer,
+                    unsigned max_evals,
+                    time_t max_time)
+    {
+        instance init_inst(deme.fields().packed_width());
+        operator()(deme, init_inst, iscorer, max_evals, max_time);
+    }
+
+protected:
+    const hc_parameters ps_params;
+    const uint64_t _total_RAM_bytes;
+    size_t _instance_bytes;
+};
+
+
+} // ~namespace moses
+} // ~namespace opencog
+
+#endif


### PR DESCRIPTION
I've made a commit to fix some examples because they were using relative path that was broken after moving example programs to their own directory.