### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,6 @@ few exceptions, most Linux distributions will provide these packages.
 > Test framework
 > http://cxxtest.sourceforge.net/ |
 > https://launchpad.net/~opencog-dev/+archive/ppa
-> Currently, opencog requires cxxtest version 3, and is not compatible
-  with version 4.
 
 ###### cogutil
 > Common OpenCog C++ utilities


### PR DESCRIPTION
Removed the following line as it is outdated and indeed works with version 4:
"Currently, opencog requires cxxtest version 3, and is not compatible with version 4."