### PR TITLE
Fix nonboosting best possible score

### DIFF
--- a/moses/moses/scoring/bscores.cc
+++ b/moses/moses/scoring/bscores.cc
@@ -286,8 +286,10 @@ behavioral_score ctruth_table_bscore::operator()(const combo_tree& tr) const
         bs.push_back(-sc);
     }
 
-    // Report the score only relative to the best-possible score.
-    bs -= _best_possible_score;
+	if (_return_weighted_score) { // if boosting
+        // Report the score only relative to the best-possible score.
+        bs -= _best_possible_score;
+    }
 
     log_candidate_bscore(tr, bs);
 
@@ -337,8 +339,11 @@ behavioral_score ctruth_table_bscore::operator()(const scored_combo_tree_set& en
         i++;
     }
 
-    // Report the score only relative to the best-possible score.
-    bs -= _best_possible_score;
+	if (_return_weighted_score) { // if boosting
+        // Report the score only relative to the best-possible score.
+        bs -= _best_possible_score;
+    }
+
     return bs;
 }
 
@@ -370,10 +375,13 @@ void ctruth_table_bscore::set_best_possible_bscore()
 
 behavioral_score ctruth_table_bscore::best_possible_bscore() const
 {
-    // The returned best score will always be zero, because the actual
-    // best score is subtracted; this is required to get boosting to
-    // work.
-    return behavioral_score(_size, 0.0);
+	if (_return_weighted_score) {
+        // The returned best score will always be zero, because the actual
+        // best score is subtracted; this is required to get boosting to
+        // work.
+        return behavioral_score(_size, 0.0);
+    }
+    return _best_possible_score;
 }
 
 behavioral_score ctruth_table_bscore::worst_possible_bscore() const

--- a/moses/moses/scoring/bscores.cc
+++ b/moses/moses/scoring/bscores.cc
@@ -280,7 +280,7 @@ behavioral_score ctruth_table_bscore::operator()(const combo_tree& tr) const
     interpreter_visitor iv(tr);
     auto interpret_tr = boost::apply_visitor(iv);
     // Evaluate the bscore components for all rows of the ctable
-    for (const CTable::value_type& vct : _ctable) {
+    for (const CTable::value_type& vct : _wrk_ctable) {
         const CTable::counter_t& c = vct.second;
         score_t sc = c.get(negate_vertex(interpret_tr(vct.first.get_variant())));
         bs.push_back(-sc);
@@ -302,7 +302,7 @@ behavioral_score ctruth_table_bscore::operator()(const combo_tree& tr) const
 /// compared to the desired output.
 behavioral_score ctruth_table_bscore::operator()(const scored_combo_tree_set& ensemble) const
 {
-    size_t sz = _ctable.size();
+    size_t sz = _wrk_ctable.size();
 
     // Step 1: accumulate the weighted prediction of each tree in
     // the ensemble.
@@ -315,7 +315,7 @@ behavioral_score ctruth_table_bscore::operator()(const scored_combo_tree_set& en
 
         // Evaluate the tree for all rows of the ctable
         size_t i=0;
-        for (const CTable::value_type& vct : _ctable) {
+        for (const CTable::value_type& vct : _wrk_ctable) {
             // Add +1 if prediction is up and -1 if prediction is down.
             vertex prediction(interpret_tr(vct.first.get_variant()));
             hypoth[i] += (id::logical_true == prediction)? weight : -weight;
@@ -331,7 +331,7 @@ behavioral_score ctruth_table_bscore::operator()(const scored_combo_tree_set& en
     // the count of the iverted prediction.
     behavioral_score bs(sz);
     size_t i =0;
-    for (const CTable::value_type& vct : _ctable) {
+    for (const CTable::value_type& vct : _wrk_ctable) {
         const CTable::counter_t& cnt = vct.second;
         vertex inverted_prediction = (hypoth[i] > 0.0) ? 
             id::logical_false : id::logical_true;
@@ -347,9 +347,10 @@ behavioral_score ctruth_table_bscore::operator()(const scored_combo_tree_set& en
     return bs;
 }
 
-void ctruth_table_bscore::set_best_possible_bscore()
+void ctruth_table_bscore::set_best_possible_bscore() const
 {
-    transform(_ctable | map_values,
+    _best_possible_score.clear();
+    transform(_wrk_ctable | map_values,
               back_inserter(_best_possible_score),
               [](const CTable::counter_t& c) {
                   // OK, this looks like magic, but here's what it does:
@@ -381,13 +382,14 @@ behavioral_score ctruth_table_bscore::best_possible_bscore() const
         // work.
         return behavioral_score(_size, 0.0);
     }
+    set_best_possible_bscore();
     return _best_possible_score;
 }
 
 behavioral_score ctruth_table_bscore::worst_possible_bscore() const
 {
     behavioral_score bs;
-    for (const CTable::value_type& vct : _ctable) {
+    for (const CTable::value_type& vct : _wrk_ctable) {
         const CTable::counter_t& cnt = vct.second;
 
         // The most that the score can improve is to flip true to false,
@@ -409,7 +411,7 @@ score_t ctruth_table_bscore::min_improv() const
     // return 0.5;
 
     score_t min_weight = FLT_MAX;
-    for (const CTable::value_type& vct : _ctable) {
+    for (const CTable::value_type& vct : _wrk_ctable) {
         const CTable::counter_t& cnt = vct.second;
 
         // The most that the score can improve is to flip

--- a/moses/moses/scoring/bscores.h
+++ b/moses/moses/scoring/bscores.h
@@ -357,22 +357,12 @@ private:
  * Note that, since p<1, that log(p) is negative, and so the second
  * term is negative.  It can be understood as a "complexity penalty".
  */
-struct ctruth_table_bscore : public bscore_base
+struct ctruth_table_bscore : public bscore_ctable_base
 {
-    template<typename Func>
-    ctruth_table_bscore(const Func& func,
-                        arity_t arity,
-                        int nsamples = -1)
-        : _ctable(func, arity, nsamples)
+    ctruth_table_bscore(const CTable& ctt)
+        : bscore_ctable_base(ctt)
     {
-        _size = _ctable.size();
-        reset_weights();
-        set_best_possible_bscore();
-    }
-
-    ctruth_table_bscore(const CTable& ctt) : _ctable(ctt)
-    {
-        _size = _ctable.size();
+        _size = _wrk_ctable.size();
         reset_weights();
         set_best_possible_bscore();
     }
@@ -388,9 +378,8 @@ struct ctruth_table_bscore : public bscore_base
     score_t min_improv() const;
 
 protected:
-    CTable _ctable;
-    behavioral_score _best_possible_score;
-    void set_best_possible_bscore();
+    mutable behavioral_score _best_possible_score;
+    void set_best_possible_bscore() const;
 };
 
 /**

--- a/tests/moses/MOSESUTest.cxxtest
+++ b/tests/moses/MOSESUTest.cxxtest
@@ -91,19 +91,15 @@ public:
         cout << BOOST_CURRENT_FUNCTION << endl;
         string data_file_path("-i" + MOSESUTest_dir + "dataset.csv");
         string max_evals("-m1000");
-        // The expected score is now 0 and not -3, since its relative
-        // to the best-possible-score, which is -3.
-        moses_test_score({data_file_path, max_evals}, 0);
+        moses_test_score({data_file_path, max_evals}, -3);
     }
     void test_it_target_ignore() {
         cout << BOOST_CURRENT_FUNCTION << endl;
         // try to predict arg1 given arg2
         string data_file_path("-i" + MOSESUTest_dir + "dataset.csv"),
             max_evals("-m1000"), target("-uarg2"), ignore_feature("-Yres");
-        // The expected score is now 0 and not -3, since its relative
-        // to the best-possible-score, which is -3.
         moses_test_score({data_file_path, max_evals, target, ignore_feature},
-                         0);
+                         -3);
     }
 
     /* SR is polynomial regression; it has a very deceptive scoring

--- a/tests/moses/dynFeatSelUTest.cxxtest
+++ b/tests/moses/dynFeatSelUTest.cxxtest
@@ -114,11 +114,11 @@ public:
         // Reset the seed, so that this, and the next test, give exactly the same result.
         opencog::randGen().seed(1);
         vector<scored_combo_tree> scts;
-        scts.push_back(string_to_scored_combo_tree("-26 and(or(and(or($16 !$23) or($16 !$36) !$22 !$30 !$53) and($16 !$36 !$59)) !$105) [score=-33, penalized score=-36.1428565979003906, complexity=11, complexity penalty=3.14285731315612793, diversity penalty=0]"));
-        scts.push_back(string_to_scored_combo_tree("-26 and(or(and(or($16 !$23) or($16 !$36) !$22 !$30 !$53) and($16 !$36 !$161)) !$105) [score=-33, penalized score=-36.1428565979003906, complexity=11, complexity penalty=3.14285731315612793, diversity penalty=0]"));
-        scts.push_back(string_to_scored_combo_tree("-26 and(or(and(or($16 !$23) or($16 !$36) !$22 !$30 !$53 !$290) and($16 !$36)) !$105) [score=-33, penalized score=-36.1428565979003906, complexity=11, complexity penalty=3.14285731315612793, diversity penalty=0]"));
-        scts.push_back(string_to_scored_combo_tree("-26 and(or(and(or($16 !$23) or($16 !$36) !$22 !$30 !$53) and($16 !$36)) or($22 !$290) !$105) [score=-33, penalized score=-36.4285736083984375, complexity=12, complexity penalty=3.42857170104980469, diversity penalty=0]"));
-        scts.push_back(string_to_scored_combo_tree("-26 and(or(and(or($16 !$23) or($16 !$36) !$22 !$30 !$53 !$290) and($16 !$36)) or($22 !$290) !$105) [score=-33, penalized score=-36.7142868041992188, complexity=13, complexity penalty=3.71428585052490234, diversity penalty=0]"));
+        scts.push_back(string_to_scored_combo_tree("-33 and(or(and(or($16 !$23) or($16 !$36) !$22 !$30 !$53) and($16 !$36 !$59)) !$105) [score=-33, penalized score=-36.1428565979003906, complexity=11, complexity penalty=3.14285731315612793, diversity penalty=0]"));
+        scts.push_back(string_to_scored_combo_tree("-33 and(or(and(or($16 !$23) or($16 !$36) !$22 !$30 !$53) and($16 !$36 !$161)) !$105) [score=-33, penalized score=-36.1428565979003906, complexity=11, complexity penalty=3.14285731315612793, diversity penalty=0]"));
+        scts.push_back(string_to_scored_combo_tree("-33 and(or(and(or($16 !$23) or($16 !$36) !$22 !$30 !$53 !$290) and($16 !$36)) !$105) [score=-33, penalized score=-36.1428565979003906, complexity=11, complexity penalty=3.14285731315612793, diversity penalty=0]"));
+        scts.push_back(string_to_scored_combo_tree("-33 and(or(and(or($16 !$23) or($16 !$36) !$22 !$30 !$53) and($16 !$36)) or($22 !$290) !$105) [score=-33, penalized score=-36.4285736083984375, complexity=12, complexity penalty=3.42857170104980469, diversity penalty=0]"));
+        scts.push_back(string_to_scored_combo_tree("-33 and(or(and(or($16 !$23) or($16 !$36) !$22 !$30 !$53 !$290) and($16 !$36)) or($22 !$290) !$105) [score=-33, penalized score=-36.7142868041992188, complexity=13, complexity penalty=3.71428585052490234, diversity penalty=0]"));
 
         string data_file_path("-i" + test_dir + "feat-sel.csv");
 

--- a/tests/moses/scoringUTest.cxxtest
+++ b/tests/moses/scoringUTest.cxxtest
@@ -23,6 +23,7 @@
 #include <cxxtest/TestSuite.h>
 
 #include <moses/moses/scoring/precision_bscore.h>
+#include <moses/moses/scoring/bscores.h>
 #include <moses/comboreduct/table/table.h>
 #include <moses/comboreduct/table/table_io.h>
 
@@ -55,6 +56,19 @@ public:
         TS_ASSERT_EQUALS(bsc.front(), precision + act_penalty);
     }
 
+	void test_ctruth_table_bscore_best_possible_bscore() {
+        Table tt = loadTable(mosesUTest_dir + "precision.csv", target_feature);
+        CTable ct = tt.compressed();
+
+        ctruth_table_bscore ctbsc(ct);
+
+        behavioral_score bsc = ctbsc.best_possible_bscore(),
+            expected_bsc = {0.0, 0.0, -2.0};
+        std::cout << "bsc = " << bsc << std::endl
+                  << "expected_bsc = " << expected_bsc << std::endl;
+        TS_ASSERT_EQUALS(bsc, expected_bsc);
+    }
+	
     // disabled till we fix best_possible_bscore
     // void test_precision2_bscore_best_possible_bscore() {
     //     CTable ct = loadCTable(mosesUTest_dir + "precision2.ctable");

--- a/tests/moses/weightedUTest.cxxtest
+++ b/tests/moses/weightedUTest.cxxtest
@@ -77,9 +77,7 @@ public:
     void test_neg_weighted_score()
     {
         // Test weighting, where some of the weights are negative or zero.
-        // Score must be exactly 2 ... except that the CTable now
-        // reports scores relative to the best-possible score, so, in
-        // this case, it will be 0.0
+        // Score must be exactly 2
         string data_file_path("-i" + weightedUTest_dir + "weight-neg.csv");
         moses_test_score({"-Hit", 
                           "-uout",
@@ -87,7 +85,7 @@ public:
                           "-m200",
                           data_file_path,
                           },
-                          0);
+                          2);
     }
 
 };


### PR DESCRIPTION
Have ctruth_table_bscore inherit bscore_ctable_base. That way

1. ctruth_table_bscore::ignore_cols is supported which may speed up evaluation dramatically when feature selection within moses is used.
2. ctruth_table_bscore::best_possible_bscore returns the correct answer (only transposes to 0 when boosting is used), which is convenient to see to which extend feature selection within moses helps before deme optimization.