### PR TITLE
Cmake update fix.

### DIFF
--- a/moses/comboreduct/ant_combo_vocabulary/ant_combo_vocabulary.cc
+++ b/moses/comboreduct/ant_combo_vocabulary/ant_combo_vocabulary.cc
@@ -102,17 +102,11 @@ bool operator!=(ant_indefinite_object_enum e, indefinite_object i) {
 
 }//~namespace ant_combo
 
-namespace std {
-
-std::istream& operator>>(std::istream& in, opencog::combo::vertex& v) {
-    return opencog::combo::stream_to_vertex<opencog::combo::ant_builtin_action,
-                            opencog::combo::ant_perception,
-                            opencog::combo::ant_action_symbol,
-                            opencog::combo::ant_indefinite_object>(in, v);
-}
-
-//std::istream& operator>>(std::istream& in, combo_tree& tr) {
-//    return stream_to_combo_tree<ant_builtin_action, ant_perception, ant_action_symbol, ant_indefinite_object>(in, tr);
-//}
-
-} // ~namespace std
+namespace opencog { namespace combo {
+    std::istream& operator>>(std::istream& in, vertex& v) {
+        return stream_to_vertex<ant_builtin_action,
+                                ant_perception,
+                                ant_action_symbol,
+                                ant_indefinite_object>(in, v);
+    }
+}} // ~namespace combo opencog

--- a/moses/comboreduct/ant_combo_vocabulary/ant_combo_vocabulary.cc
+++ b/moses/comboreduct/ant_combo_vocabulary/ant_combo_vocabulary.cc
@@ -102,15 +102,17 @@ bool operator!=(ant_indefinite_object_enum e, indefinite_object i) {
 
 }//~namespace ant_combo
 
-namespace opencog { namespace combo {
-  
-std::istream& operator>>(std::istream& in, vertex& v) {
-    return stream_to_vertex<ant_builtin_action, ant_perception, ant_action_symbol, ant_indefinite_object>(in, v);
+namespace std {
+
+std::istream& operator>>(std::istream& in, opencog::combo::vertex& v) {
+    return opencog::combo::stream_to_vertex<opencog::combo::ant_builtin_action,
+                            opencog::combo::ant_perception,
+                            opencog::combo::ant_action_symbol,
+                            opencog::combo::ant_indefinite_object>(in, v);
 }
 
-std::istream& operator>>(std::istream& in, combo_tree& tr) {
-    return stream_to_combo_tree<ant_builtin_action, ant_perception, ant_action_symbol, ant_indefinite_object>(in, tr);
-}  
-  
-} // ~namespace combo
-} // ~namespace opencog
+//std::istream& operator>>(std::istream& in, combo_tree& tr) {
+//    return stream_to_combo_tree<ant_builtin_action, ant_perception, ant_action_symbol, ant_indefinite_object>(in, tr);
+//}
+
+} // ~namespace std

--- a/moses/comboreduct/combo/action_symbol.cc
+++ b/moses/comboreduct/combo/action_symbol.cc
@@ -26,10 +26,6 @@
 
 namespace opencog { namespace combo {
 
-    action_symbol action_symbol_base::get_instance(const std::string& name){
-        return NULL;
-    }
-
     std::ostream& operator<<(std::ostream& out, action_symbol as) {
         OC_ASSERT(as);
         return out << as->get_name();

--- a/moses/comboreduct/combo/action_symbol.cc
+++ b/moses/comboreduct/combo/action_symbol.cc
@@ -26,10 +26,14 @@
 
 namespace opencog { namespace combo {
 
-std::ostream& operator<<(std::ostream& out, action_symbol as) {
-    OC_ASSERT(as);
-    return out << as->get_name();
-}
+    action_symbol action_symbol_base::get_instance(const std::string& name){
+        return NULL;
+    }
+
+    std::ostream& operator<<(std::ostream& out, action_symbol as) {
+        OC_ASSERT(as);
+        return out << as->get_name();
+    }
 
 } // ~namespace combo
 } // ~namespace opencog

--- a/moses/comboreduct/combo/action_symbol.h
+++ b/moses/comboreduct/combo/action_symbol.h
@@ -35,7 +35,9 @@ class action_symbol_base : public operator_base {
 public:
     virtual ~action_symbol_base() {}
 
-    static const action_symbol_base* get_instance(const std::string& name);
+    static const action_symbol_base* get_instance(const std::string& name) {
+         return NULL;
+    }
 };
 
 typedef const action_symbol_base* action_symbol;

--- a/moses/comboreduct/combo/action_symbol.h
+++ b/moses/comboreduct/combo/action_symbol.h
@@ -34,10 +34,12 @@ namespace opencog { namespace combo {
 class action_symbol_base : public operator_base {
 public:
     virtual ~action_symbol_base() {}
+
+    static const action_symbol_base* get_instance(const std::string& name);
 };
 
 typedef const action_symbol_base* action_symbol;
-  
+
 std::ostream& operator<<(std::ostream&, combo::action_symbol);
 
 } // ~namespace combo

--- a/moses/comboreduct/combo/builtin_action.cc
+++ b/moses/comboreduct/combo/builtin_action.cc
@@ -26,10 +26,14 @@
 
 namespace opencog { namespace combo {
 
-std::ostream& operator<<(std::ostream& out, combo::builtin_action a) {
-    OC_ASSERT(a);
-    return out << a->get_name();
-}
+    builtin_action builtin_action_base::get_instance(const std::string& name){
+        return NULL;
+    }
+
+    std::ostream& operator<<(std::ostream& out, combo::builtin_action a) {
+        OC_ASSERT(a);
+        return out << a->get_name();
+    }
 
 } // ~namespace combo
 } // ~namespace opencog

--- a/moses/comboreduct/combo/builtin_action.cc
+++ b/moses/comboreduct/combo/builtin_action.cc
@@ -26,10 +26,6 @@
 
 namespace opencog { namespace combo {
 
-    builtin_action builtin_action_base::get_instance(const std::string& name){
-        return NULL;
-    }
-
     std::ostream& operator<<(std::ostream& out, combo::builtin_action a) {
         OC_ASSERT(a);
         return out << a->get_name();

--- a/moses/comboreduct/combo/builtin_action.h
+++ b/moses/comboreduct/combo/builtin_action.h
@@ -60,7 +60,9 @@ class builtin_action_base : public operator_base {
 public:
     virtual ~builtin_action_base() {}
 
-    static const builtin_action_base* get_instance(const std::string& name);
+    static const builtin_action_base* get_instance(const std::string& name) {
+        return NULL;
+    }
 
     //action properties required for reduction
 #ifdef NO_DEFAULT_ACTION_PROPERTY_METHODS

--- a/moses/comboreduct/combo/builtin_action.h
+++ b/moses/comboreduct/combo/builtin_action.h
@@ -34,7 +34,7 @@
 #include <moses/comboreduct/combo/operator_base.h>
 
 //if the user wants to use the reduct engine it is recommended to
-//enable the following macro in order to allow the compiler to detect 
+//enable the following macro in order to allow the compiler to detect
 //action property methods which have not been implemented
 #define NO_DEFAULT_ACTION_PROPERTY_METHODS
 
@@ -59,6 +59,8 @@ namespace opencog { namespace combo {
 class builtin_action_base : public operator_base {
 public:
     virtual ~builtin_action_base() {}
+
+    static const builtin_action_base* get_instance(const std::string& name);
 
     //action properties required for reduction
 #ifdef NO_DEFAULT_ACTION_PROPERTY_METHODS
@@ -112,6 +114,7 @@ public:
         static const std::set<const builtin_action_base*> tmp;
         return tmp;
     }
+
 #endif
 };
 

--- a/moses/comboreduct/combo/indefinite_object.cc
+++ b/moses/comboreduct/combo/indefinite_object.cc
@@ -26,10 +26,6 @@
 
 namespace opencog { namespace combo {
 
-    indefinite_object indefinite_object_base::get_instance(const std::string& name){
-        return NULL;
-    }
-
     std::ostream& operator<<(std::ostream& out, indefinite_object i) {
         return out << i->get_name();
     }

--- a/moses/comboreduct/combo/indefinite_object.cc
+++ b/moses/comboreduct/combo/indefinite_object.cc
@@ -26,9 +26,13 @@
 
 namespace opencog { namespace combo {
 
-std::ostream& operator<<(std::ostream& out, indefinite_object i) {
-  return out << i->get_name();
-}
+    indefinite_object indefinite_object_base::get_instance(const std::string& name){
+        return NULL;
+    }
+
+    std::ostream& operator<<(std::ostream& out, indefinite_object i) {
+        return out << i->get_name();
+    }
 
 } // ~namespace combo
 } // ~namespace opencog

--- a/moses/comboreduct/combo/indefinite_object.h
+++ b/moses/comboreduct/combo/indefinite_object.h
@@ -37,7 +37,9 @@ class indefinite_object_base : public operator_base {
 public:
     virtual ~indefinite_object_base() {}
 
-    static const indefinite_object_base* get_instance(const std::string& name);
+    static const indefinite_object_base* get_instance(const std::string& name) {
+        return NULL;
+    }
 };
 
 typedef const indefinite_object_base* indefinite_object;

--- a/moses/comboreduct/combo/indefinite_object.h
+++ b/moses/comboreduct/combo/indefinite_object.h
@@ -30,12 +30,14 @@
 #include <moses/comboreduct/combo/operator_base.h>
 
 namespace opencog { namespace combo {
-  
+
 //indefinite_object inherits from operator_base
 //without additional properties
 class indefinite_object_base : public operator_base {
 public:
     virtual ~indefinite_object_base() {}
+
+    static const indefinite_object_base* get_instance(const std::string& name);
 };
 
 typedef const indefinite_object_base* indefinite_object;

--- a/moses/comboreduct/combo/iostream_combo.h
+++ b/moses/comboreduct/combo/iostream_combo.h
@@ -1,4 +1,4 @@
-/** iostream_combo.h --- 
+/** iostream_combo.h ---
  *
  * Copyright (C) 2012 OpenCog Foundation
  *
@@ -9,12 +9,12 @@
  * it under the terms of the GNU Affero General Public License v3 as
  * published by the Free Software Foundation and including the exceptions
  * at http://opencog.org/wiki/Licenses
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program; if not, write to:
  * Free Software Foundation, Inc.,
@@ -157,7 +157,7 @@ void str_to_vertex(const std::string& str, vertex& v)
     }
     // should be definite object then
     else {
-        // Any word character (alphanumeric characters plus the 
+        // Any word character (alphanumeric characters plus the
         // underscore). If you find this too constraining, feel free to
         // relax.
         static const boost::regex e("[\\w-]+");
@@ -274,7 +274,7 @@ std::ostream& operator<<(std::ostream&, const ann_type&);
 std::ostream& operator<<(std::ostream&, const builtin&);
 std::ostream& operator<<(std::ostream&, const wild_card&);
 std::ostream& operator<<(std::ostream&, const argument&);
-// output argument $n when positive, !$n when negative 
+// output argument $n when positive, !$n when negative
 std::ostream& ostream_abbreviate_literal(std::ostream&, const argument&,
                                          const std::vector<std::string>& labels =
                                          std::vector<std::string>());

--- a/moses/comboreduct/combo/operator_base.h
+++ b/moses/comboreduct/combo/operator_base.h
@@ -48,6 +48,10 @@ namespace opencog { namespace combo {
     virtual type_tree get_output_type_tree() const = 0;
     //return the type tree of the input argument of index i
     virtual const type_tree& get_input_type_tree(arity_t i) const = 0;
+
+    // Default behavior for convert the string to operator_base type.
+    static const operator_base* get_instance(const std::string& name);
+
   };
 
 }} // ~namespace combo opencog

--- a/moses/comboreduct/combo/perception.cc
+++ b/moses/comboreduct/combo/perception.cc
@@ -26,10 +26,6 @@
 
 namespace opencog { namespace combo {
 
-    perception perception_base::get_instance(const std::string& name){
-        return NULL;
-    }
-
     std::ostream& operator<<(std::ostream& out, perception p) {
         OC_ASSERT(p);
         return out << p->get_name();

--- a/moses/comboreduct/combo/perception.cc
+++ b/moses/comboreduct/combo/perception.cc
@@ -26,10 +26,14 @@
 
 namespace opencog { namespace combo {
 
-std::ostream& operator<<(std::ostream& out, perception p) {
-    OC_ASSERT(p);
-    return out << p->get_name();
-}
+    perception perception_base::get_instance(const std::string& name){
+        return NULL;
+    }
+
+    std::ostream& operator<<(std::ostream& out, perception p) {
+        OC_ASSERT(p);
+        return out << p->get_name();
+    }
 
 } // ~namespace combo
 } // ~namespace opencog

--- a/moses/comboreduct/combo/perception.h
+++ b/moses/comboreduct/combo/perception.h
@@ -58,7 +58,9 @@ class perception_base : public operator_base {
 public:
     virtual ~perception_base() {}
 
-    static const perception_base* get_instance(const std::string& name);
+    static const perception_base* get_instance(const std::string& name) {
+        return NULL;
+    }
 
     //action properties required for reduction
 #ifdef NO_DEFAULT_ACTION_PROPERTY_METHODS

--- a/moses/comboreduct/combo/perception.h
+++ b/moses/comboreduct/combo/perception.h
@@ -30,7 +30,7 @@
 #include <moses/comboreduct/combo/operator_base.h>
 
 //if the user wants to use the reduct engine it is recommended to
-//enable the following macro in order to allow the compiler to detect 
+//enable the following macro in order to allow the compiler to detect
 //perception property methods which have not been implemented
 #define NO_DEFAULT_PERCEPTION_PROPERTY_METHODS
 
@@ -57,7 +57,9 @@ namespace opencog { namespace combo {
 class perception_base : public operator_base {
 public:
     virtual ~perception_base() {}
-  
+
+    static const perception_base* get_instance(const std::string& name);
+
     //action properties required for reduction
 #ifdef NO_DEFAULT_ACTION_PROPERTY_METHODS
     virtual bool is_ultrametric() const = 0;

--- a/moses/comboreduct/combo/vertex.cc
+++ b/moses/comboreduct/combo/vertex.cc
@@ -33,19 +33,12 @@ bool operator<(const combo_tree& lt, const combo_tree& rt) {
     return size_tree_order<vertex>()(lt, rt);
 }
 
-std::istream& operator>>(std::istream& in, vertex& v) {
-    return stream_to_vertex<builtin_action_base,
-                            perception_base,
-                            action_symbol_base,
-                            indefinite_object_base>(in, v);
-}
-
-std::istream& operator>>(std::istream& in, combo_tree& tr) {
-    return stream_to_combo_tree<builtin_action_base,
-                            perception_base,
-                            action_symbol_base,
-                            indefinite_object_base>(in, tr);
-}
+//std::istream& operator>>(std::istream& in, combo_tree& tr) {
+    //return stream_to_combo_tree<builtin_action_base,
+                            //perception_base,
+                            //action_symbol_base,
+                            //indefinite_object_base>(in, tr);
+//}
 
 bool is_procedure_call(const vertex& v)
 {
@@ -277,3 +270,12 @@ void copy_without_null_vertices(combo_tree::iterator src,
 }
 
 }} // ~namespaces combo opencog
+
+namespace std {
+    std::istream& operator>>(std::istream& in, opencog::combo::vertex& v) {
+        return opencog::combo::stream_to_vertex<opencog::combo::builtin_action_base,
+                                opencog::combo::perception_base,
+                                opencog::combo::action_symbol_base,
+                                opencog::combo::indefinite_object_base>(in, v);
+    }
+} // ~namespace std

--- a/moses/comboreduct/combo/vertex.cc
+++ b/moses/comboreduct/combo/vertex.cc
@@ -33,12 +33,12 @@ bool operator<(const combo_tree& lt, const combo_tree& rt) {
     return size_tree_order<vertex>()(lt, rt);
 }
 
-//std::istream& operator>>(std::istream& in, combo_tree& tr) {
-    //return stream_to_combo_tree<builtin_action_base,
-                            //perception_base,
-                            //action_symbol_base,
-                            //indefinite_object_base>(in, tr);
-//}
+std::istream& operator>>(std::istream& in, vertex& v) {
+    return stream_to_vertex<builtin_action_base,
+                            perception_base,
+                            action_symbol_base,
+                            indefinite_object_base>(in, v);
+}
 
 bool is_procedure_call(const vertex& v)
 {
@@ -270,12 +270,3 @@ void copy_without_null_vertices(combo_tree::iterator src,
 }
 
 }} // ~namespaces combo opencog
-
-namespace std {
-    std::istream& operator>>(std::istream& in, opencog::combo::vertex& v) {
-        return opencog::combo::stream_to_vertex<opencog::combo::builtin_action_base,
-                                opencog::combo::perception_base,
-                                opencog::combo::action_symbol_base,
-                                opencog::combo::indefinite_object_base>(in, v);
-    }
-} // ~namespace std

--- a/moses/comboreduct/combo/vertex.cc
+++ b/moses/comboreduct/combo/vertex.cc
@@ -32,7 +32,21 @@ namespace opencog { namespace combo {
 bool operator<(const combo_tree& lt, const combo_tree& rt) {
     return size_tree_order<vertex>()(lt, rt);
 }
-        
+
+std::istream& operator>>(std::istream& in, vertex& v) {
+    return stream_to_vertex<builtin_action_base,
+                            perception_base,
+                            action_symbol_base,
+                            indefinite_object_base>(in, v);
+}
+
+std::istream& operator>>(std::istream& in, combo_tree& tr) {
+    return stream_to_combo_tree<builtin_action_base,
+                            perception_base,
+                            action_symbol_base,
+                            indefinite_object_base>(in, tr);
+}
+
 bool is_procedure_call(const vertex& v)
 {
     return (boost::get<procedure_call>(&v));
@@ -206,7 +220,7 @@ contin_t cast_contin(const vertex& v)
         return 0;
     }
 }
-        
+
 bool operator==(const vertex& v, procedure_call h)
 {
     if (const procedure_call* vh = boost::get<procedure_call>(&v))
@@ -252,7 +266,7 @@ vertex swap_and_or(const vertex& v)
     OC_ASSERT(v == id::logical_or || v == id::logical_and);
     return v == id::logical_and ? id::logical_or : id::logical_and;
 }
-        
+
 void copy_without_null_vertices(combo_tree::iterator src,
                                 combo_tree& dst_tr, combo_tree::iterator dst)
 {

--- a/moses/comboreduct/combo/vertex.h
+++ b/moses/comboreduct/combo/vertex.h
@@ -98,7 +98,7 @@ enum __attribute__ ((packed)) builtin
     lambda,
     apply,
 
-    // XXX This should be obsoleted by cond, at some point. 
+    // XXX This should be obsoleted by cond, at some point.
     // Maybe action_boolean_if too, I guess?
     contin_if,
 

--- a/moses/comboreduct/combo/vertex.h
+++ b/moses/comboreduct/combo/vertex.h
@@ -159,6 +159,8 @@ typedef std::vector<argument_list> argument_list_list;
 typedef argument_list_list::iterator argument_list_list_it;
 typedef argument_list_list::const_iterator argument_list_list_const_it;
 
+// Disambiguate stream operator; use the one declared in util/tree.h
+std::istream& operator>>(std::istream& in, combo::vertex& v);
 
 // -------------------------------------------------------
 // contin_t == vertex
@@ -807,9 +809,6 @@ namespace std
             return opencog::combo::hash_value(v);
         }
     };
-
-    // Disambiguate stream operator; use the one declared in util/tree.h
-    std::istream& operator>>(std::istream& in, opencog::combo::vertex& v);
 }
 
 #endif

--- a/moses/comboreduct/combo/vertex.h
+++ b/moses/comboreduct/combo/vertex.h
@@ -159,8 +159,6 @@ typedef std::vector<argument_list> argument_list_list;
 typedef argument_list_list::iterator argument_list_list_it;
 typedef argument_list_list::const_iterator argument_list_list_const_it;
 
-// Disambiguate stream operator; use the one declared in util/tree.h
-std::istream& operator>>(std::istream& in, combo::vertex& v);
 
 // -------------------------------------------------------
 // contin_t == vertex
@@ -538,7 +536,7 @@ typedef combo_tree_ns_set::const_iterator combo_tree_ns_set_const_it;
 bool operator<(const combo_tree& lt, const combo_tree& rt);
 
 // Disambiguate stream operator; use the one declared in util/tree.h
-std::istream& operator>>(std::istream& in, combo::combo_tree& tr);
+//std::istream& operator>>(std::istream& in, combo::combo_tree& tr);
 
 // -------------------------------------------------------
 // Algebraic properties
@@ -809,6 +807,9 @@ namespace std
             return opencog::combo::hash_value(v);
         }
     };
+
+    // Disambiguate stream operator; use the one declared in util/tree.h
+    std::istream& operator>>(std::istream& in, opencog::combo::vertex& v);
 }
 
 #endif

--- a/moses/feature-selection/CMakeLists.txt
+++ b/moses/feature-selection/CMakeLists.txt
@@ -1,10 +1,8 @@
-FIND_LIBRARY( MOSES_LIB moses  )
-
 ADD_SUBDIRECTORY(scorers)
 ADD_SUBDIRECTORY(main)
 ADD_SUBDIRECTORY(man)
 
-ADD_LIBRARY(feature_selection STATIC
+ADD_LIBRARY(feature_selection SHARED
 	algo/deme_optimize
 	algo/incremental
 	algo/random
@@ -15,7 +13,7 @@ ADD_LIBRARY(feature_selection STATIC
 )
 
 TARGET_LINK_LIBRARIES(feature_selection
-    moses
+    INTERFACE moses
 	${COGUTIL_LIBRARY}
 	${Boost_PROGRAM_OPTIONS_LIBRARY} 
 )

--- a/moses/feature-selection/CMakeLists.txt
+++ b/moses/feature-selection/CMakeLists.txt
@@ -1,4 +1,10 @@
-ADD_LIBRARY(feature_selection SHARED
+FIND_LIBRARY( MOSES_LIB moses  )
+
+ADD_SUBDIRECTORY(scorers)
+ADD_SUBDIRECTORY(main)
+ADD_SUBDIRECTORY(man)
+
+ADD_LIBRARY(feature_selection STATIC
 	algo/deme_optimize
 	algo/incremental
 	algo/random
@@ -9,13 +15,10 @@ ADD_LIBRARY(feature_selection SHARED
 )
 
 TARGET_LINK_LIBRARIES(feature_selection
+    moses
 	${COGUTIL_LIBRARY}
 	${Boost_PROGRAM_OPTIONS_LIBRARY} 
 )
-
-ADD_SUBDIRECTORY(scorers)
-ADD_SUBDIRECTORY(main)
-ADD_SUBDIRECTORY(man)
 
 # Install library
 IF (WIN32)

--- a/moses/moses/CMakeLists.txt
+++ b/moses/moses/CMakeLists.txt
@@ -28,7 +28,7 @@ ADD_SUBDIRECTORY (eda)
 ADD_SUBDIRECTORY (main)
 ADD_SUBDIRECTORY (man)
 
-ADD_LIBRARY (moses SHARED
+ADD_LIBRARY (moses STATIC
 	deme/deme_expander
 	deme/feature_selector
 

--- a/moses/moses/CMakeLists.txt
+++ b/moses/moses/CMakeLists.txt
@@ -28,7 +28,7 @@ ADD_SUBDIRECTORY (eda)
 ADD_SUBDIRECTORY (main)
 ADD_SUBDIRECTORY (man)
 
-ADD_LIBRARY (moses STATIC
+ADD_LIBRARY (moses SHARED
 	deme/deme_expander
 	deme/feature_selector
 

--- a/moses/moses/representation/field_set.h
+++ b/moses/moses/representation/field_set.h
@@ -210,7 +210,7 @@ struct field_set
             return step_size / contin_t(1UL << depth);
         }
 
-        // XXX should be enum ... 
+        // XXX should be enum ...
         static const disc_t Stop;  // 0
         static const disc_t Left;  // 1
         static const disc_t Right; // 2
@@ -455,11 +455,11 @@ struct field_set
     ///
     /// The intended use of this is to merge two high-scoring instances
     /// into one. Thus, typically, both target and reference will be high
-    /// scorers, and base a previous high scorer. Then the difference 
+    /// scorers, and base a previous high scorer. Then the difference
     /// (reference minus base) are those bits that made reference into
     /// such a great instance -- so copy those fields into the target.
     /// For many simple hill-climbing, this actually works, because high
-    /// scoring knob settings are strongly correlated, even if we don't 
+    /// scoring knob settings are strongly correlated, even if we don't
     /// really know what these are (i.e. have not used an estimation-of-
     /// distribution/Bayesian-optimization algorithm to figure out the
     /// correlations). That is, we just blindly assume a correlation, and
@@ -479,7 +479,7 @@ struct field_set
             if (*bit != *rit) *tit = *rit;
         }
     }
-    
+
     // The fields are organized so that term fields come first,
     // followed by the continuous fields, and then the discrete
     // fields. These are then followed by the 1-bit (boolean)
@@ -636,7 +636,7 @@ struct field_set
         size_t end_disc_idx = end_disc_raw_idx();
 
         // @todo: compute at the start in _fields - could be faster..
-        OC_ASSERT(raw_idx >= begin_disc_idx && 
+        OC_ASSERT(raw_idx >= begin_disc_idx &&
                   raw_idx < end_disc_idx);
 
         // There's exactly one disc_spec per disc field.
@@ -644,7 +644,7 @@ struct field_set
     }
 
     /**
-     * Get length, in terms of 'raw fields', of an instance of a 
+     * Get length, in terms of 'raw fields', of an instance of a
      * contin.  A contin variable consists of at most
      * contin_spec::depth() 'raw fields' or 'pseudo-bits'.  Each
      * pseudo-bit can take one of three values: L, R or S, which
@@ -798,7 +798,7 @@ protected:
 
         Self& operator--()
         {
-            static const packed_t reset = packed_t(1 << (bits_per_packed_t - 1));
+            static const packed_t reset = packed_t(1UL << (bits_per_packed_t - 1));
             _mask >>= 1;
             if (!_mask) {
                 _mask = reset;

--- a/tests/comboreduct/type_checker/CMakeLists.txt
+++ b/tests/comboreduct/type_checker/CMakeLists.txt
@@ -1,6 +1,6 @@
 ADD_CXXTEST(type_treeUTest)
 TARGET_LINK_LIBRARIES(type_treeUTest
-	comboreduct
 	comboant
+	comboreduct
 	${COGUTIL_LIBRARY}
 )


### PR DESCRIPTION
After cmake version 3.2.2 (that's the default for ubuntu 15.10), it had undefined reference problems. It happens in newer versions too, like 3.4.1.
The dependency of libcomboreduct and libcomboant was solved in the code. See issue #29 for details.
The dependency between libfeature_selection and libmoses was solved updating the interface in the cmake config files. See issue #29 for details.
After accepting this pull request, close issue #27 and #29. 