### PR TITLE
Build fix: changed abs() -> fabs() (or std::abs?) to be built with G++ 7.1.0

### DIFF
--- a/moses/comboreduct/combo/similarity.cc
+++ b/moses/comboreduct/combo/similarity.cc
@@ -217,7 +217,7 @@ size_t tree_similarity(const tree_branch_vector& av,
 		catch (const std::out_of_range& oor)
 		{}
 
-		dist += abs(acnt - bcnt);
+		dist += fabs(acnt - bcnt);
 	}
 
 	// Add anything in bv that was not in av.


### PR DESCRIPTION
MOSES build with newer(?) G++ fails with the following error:

home/mhatta/work/Debian/opencog/opencog-moses/opencog-moses-3.6.10~git20170807.
a3a37c9/moses/comboreduct/combo/similarity.cc: In function ‘size_t opencog::comb
o::tree_similarity(const tree_branch_vector&, const tree_branch_vector&)’:      
/home/mhatta/work/Debian/opencog/opencog-moses/opencog-moses-3.6.10~git20170807.a3a37c9/moses/comboreduct/combo/similarity.cc:220:26: error: call of overloaded 
‘abs(size_t)’ is ambiguous                                                         dist += abs(acnt - bcnt);                                                    
                          ^ 

Changing abs() to fabs() fixes this.  Or std::abs instead of fabs?

A include file in cogutils needs to be fixed too.