### PR TITLE
Move epsilon to where its clearly visible/adjustable

### DIFF
--- a/moses/moses/metapopulation/merging.cc
+++ b/moses/moses/metapopulation/merging.cc
@@ -533,13 +533,15 @@ void metapopulation::keep_top_unique_candidates(
                 logger().debug(ss.str());
             }
 
+#define EPSILON static_cast<score_t>(1e-6)
+
             // Remove duplicates till at most top_cnd unique
             // candidates remains
             for (auto it = deme.begin(), prev_it = it++;
                  it != deme.begin() + top_cnd;) {
                 score_t sc = (select_tag()(*it)).get_penalized_score(),
                     prev_sc = (select_tag()(*prev_it)).get_penalized_score();
-                if (is_approx_eq(prev_sc, sc)) { // they might be identical
+                if (is_approx_eq(prev_sc, sc, EPSILON)) { // they might be identical
                     combo_tree tr = rep.get_candidate(*it, true),
                         prev_tr = rep.get_candidate(*prev_it, true);
                     if (prev_tr == tr) { // they actually are identical

--- a/moses/moses/moses/types.cc
+++ b/moses/moses/moses/types.cc
@@ -153,11 +153,14 @@ bool composite_score::operator==(const composite_score &r) const
 {
     // Note: this check is used in iostream_bscored_combo_treeUTest
     // and a simple equality test will fail on some cpu/os combos.
-    return is_approx_eq(score, r.get_score())
-        and is_approx_eq(complexity, r.get_complexity())
-        and is_approx_eq(complexity_penalty, r.get_complexity_penalty())
-        and is_approx_eq(diversity_penalty, r.get_diversity_penalty())
-        and is_approx_eq(penalized_score, r.get_penalized_score());
+
+    // Note that complexity_t is an unsigned int.
+#define EPSILON static_cast<score_t>(1e-6)
+    return is_approx_eq(score, r.get_score(), EPSILON)
+        and complexity == r.get_complexity()
+        and is_approx_eq(complexity_penalty, r.get_complexity_penalty(), EPSILON)
+        and is_approx_eq(diversity_penalty, r.get_diversity_penalty(), EPSILON)
+        and is_approx_eq(penalized_score, r.get_penalized_score(), EPSILON);
 }
 
 static const std::string behavioral_score_prefix_str = "behavioral score:";


### PR DESCRIPTION
The developer can clearly see what "approximately equal" really means.