### PR TITLE
Use C/C++ names for numeric math literals

### DIFF
--- a/moses/comboreduct/reduct/contin_rules.cc
+++ b/moses/comboreduct/reduct/contin_rules.cc
@@ -991,7 +991,7 @@ void reduce_sin::operator()(combo_tree& tr, combo_tree::iterator it) const
     else if (is_contin(*sin_child))
         c_it = sin_child;
 
-    // Put the constant term into the range (-PI, PI]
+    // Put the constant term into the range (-M_PI, M_PI]
     if (c_it != tr.end()) {
         OC_ASSERT(is_contin(*c_it),
                   "sin_child isn't of type contin (reduce_sin).");
@@ -1001,8 +1001,8 @@ void reduce_sin::operator()(combo_tree& tr, combo_tree::iterator it) const
             *it = FP_NAN;
             return;
         }
-        if (c <= -PI || c > PI)
-            *c_it = fmod((c+PI), 2.0*PI) - PI;
+        if (c <= -M_PI || c > M_PI)
+            *c_it = fmod((c+M_PI), 2.0*M_PI) - M_PI;
     }
 }
 

--- a/moses/comboreduct/reduct/mixed_rules.cc
+++ b/moses/comboreduct/reduct/mixed_rules.cc
@@ -1217,7 +1217,7 @@ void reduce_gt_zero_sin::operator()(combo_tree& tr,combo_tree::iterator it) cons
                 *sin1_it = id::times;
                 copy1_tr.append_child(sin1_it, -1.0);
                 pre_it new_plus = copy1_tr.wrap(sin1_it, id::plus);
-                copy1_tr.append_child(new_plus, (contin_t)PI);
+                copy1_tr.append_child(new_plus, (contin_t)M_PI);
                 (*_reduction)(copy1_tr);
                 if(*copy1_tr.begin()==id::logical_true) {
                     *it = id::logical_true;
@@ -1234,7 +1234,7 @@ void reduce_gt_zero_sin::operator()(combo_tree& tr,combo_tree::iterator it) cons
                 //copy old assumptions, end
                 pre_it sin2_it = copy2_tr.begin().begin();
                 *sin2_it = id::plus;
-                copy2_tr.append_child(sin2_it, (contin_t)PI);
+                copy2_tr.append_child(sin2_it, (contin_t)M_PI);
                 copy2_tr.append_child(copy2_tr.wrap(sin2_it, id::times), -1.0);
                 (*_reduction)(copy2_tr);
                 if(*copy2_tr.begin()==id::logical_false) {

--- a/moses/comboreduct/table/table.h
+++ b/moses/comboreduct/table/table.h
@@ -849,7 +849,7 @@ private:
     {
         if (contin_arity == 0)
             return 1;
-        else return COEF_SAMPLE_COUNT*log(contin_arity + EXPONENTIAL);
+        else return COEF_SAMPLE_COUNT*log(contin_arity + M_E);
     }
 
 };

--- a/moses/moses/main/eval-candidate-likelihood.cc
+++ b/moses/moses/main/eval-candidate-likelihood.cc
@@ -25,6 +25,8 @@
  * be used for instance in model combination to weight each candidate.
  */
 
+#include <ext/numeric>  // needed for __gnu_cxx::power
+
 #include <boost/math/special_functions/binomial.hpp>
 #include <boost/range/algorithm_ext/for_each.hpp>
 #include <boost/algorithm/string/trim.hpp>


### PR DESCRIPTION
Avoid idiosyncratic, non-standard names.