### PR TITLE
Fix metapop logging

### DIFF
--- a/moses/moses/metapopulation/merging.cc
+++ b/moses/moses/metapopulation/merging.cc
@@ -144,10 +144,10 @@ void metapopulation::rescore()
 #endif
 }
 
-/// Merge the given set of candidates into the metapopulation.
-/// It is assumed that these candiates have already be vetted for
-/// quality, quantity, suitability, etc.  This simply performs that
-/// final, actual merge.
+/// Merge the given set of candidates into the metapopulation.  It is
+/// assumed that these candidates have already be vetted for quality,
+/// quantity, suitability, etc.  This simply performs that final,
+/// actual merge.
 void metapopulation::merge_candidates(scored_combo_tree_set& candidates)
 {
     if (logger().is_debug_enabled()) {

--- a/moses/moses/metapopulation/metapopulation.cc
+++ b/moses/moses/metapopulation/metapopulation.cc
@@ -248,9 +248,8 @@ const combo_tree& metapopulation::best_tree() const
 
 std::ostream& metapopulation::ostream_metapop(std::ostream& out, int maxcnt) const
 {
-    const scored_combo_tree_set& tree_set = best_candidates();
     int cnt = 0;
-    for (const scored_combo_tree& sct : tree_set) {
+    for (const scored_combo_tree& sct : _scored_trees) {
         if (maxcnt < ++cnt) break;
         out << sct;
     }

--- a/moses/moses/metapopulation/metapopulation.h
+++ b/moses/moses/metapopulation/metapopulation.h
@@ -570,7 +570,7 @@ protected:
     std::mutex _merge_mutex;
 
     // For now, the ensemble is along for the ride.  Someday, perhaps
-    // it should enjoy life ndependently of the metapop.
+    // it should enjoy life independently of the metapop.
     ensemble _ensemble;
 };
 

--- a/moses/moses/metapopulation/metapopulation.h
+++ b/moses/moses/metapopulation/metapopulation.h
@@ -528,6 +528,11 @@ public:
     // log the best candidates
     void log_best_candidates() const;
 
+    // Output the top n candidates (with behavior scores) of the
+    // metapopulation. This function is used for fine logging to
+    // deeply probe the metapopulation.
+    //
+    // TODO: we may want to output the visited status as well
     std::ostream& ostream_metapop(std::ostream&, int n = INT_MAX) const;
 
 private:

--- a/moses/moses/moses/local_moses.cc
+++ b/moses/moses/moses/local_moses.cc
@@ -189,10 +189,12 @@ void local_moses(metapopulation& mp,
         }
 
         // I find this particularly useful for studying diversity but
-        // it could be relaxed and printed whatever
+        // it could be relaxed to be printed regardless of whether
+        // diversity is enabled or not.
         if (logger().is_debug_enabled() and mp.diversity_enabled()) {
             std::stringstream ss;
-            ss << pa.max_cnd_output << " best candidates of the metapopulation (with scores and visited status):" << std::endl;
+            ss << "Top " << pa.max_cnd_output
+               << " candidates of the metapopulation:" << std::endl;
             mp.ostream_metapop(ss, pa.max_cnd_output);
             logger().debug(ss.str());
         }

--- a/moses/moses/moses/moses_main.h
+++ b/moses/moses/moses/moses_main.h
@@ -221,7 +221,7 @@ struct metapop_printer
                     logger().warn("No candidate is good enough to be returned. "
                                   "Yeah that's bad!");
                 else
-                    logger().info("Best candidates:\n%s", ssb.str().c_str());
+                    logger().info("Best candidate:\n%s", ssb.str().c_str());
             }
         }
 


### PR DESCRIPTION
Fix #87, logging the whole metapopulation when fine is enabled (as it used to).