### PR TITLE
Remove -b flag cause it's easy to confuse with --balance

### DIFF
--- a/moses/moses/main/moses_exec_def.h
+++ b/moses/moses/main/moses_exec_def.h
@@ -36,7 +36,7 @@ using namespace std;
 // Available abbreviations are: O
 static const pair<string, string> rand_seed_opt("random-seed", "r");
 static const pair<string, string> problem_opt("problem", "H");
-static const pair<string, string> nsamples_opt("nsamples", "b");
+static const string nsamples_opt("nsamples");
 static const pair<string, string> min_rand_input_opt("min-rand-input", "q");
 static const pair<string, string> max_rand_input_opt("max-rand-input", "w");
 static const pair<string, string> max_evals_opt("max-evals", "m");

--- a/moses/moses/main/problem-params.cc
+++ b/moses/moses/main/problem-params.cc
@@ -224,7 +224,7 @@ problem_params::add_options(boost::program_options::options_description& desc)
          "maj, demo, majority problem\n\n"
          "sr, demo, regression of f_n(x) = sum_{k=1,n} x^k\n")
 
-        (opt_desc_str(nsamples_opt).c_str(),
+        (nsamples_opt.c_str(),
          po::value<int>(&nsamples)->default_value(-1),
          "Number of samples to describe the problem. "
          "If nsample is negative, null or larger than the maximum "

--- a/moses/moses/man/moses.1
+++ b/moses/moses/man/moses.1
@@ -66,8 +66,7 @@ moses \- meta-optimizing semantic evolutionary search solver
 .IR algo ]
 .RB [ \-B
 .IR knob_effort ]
-.RB [ \-b
-.IR nsamples ]
+.RB [ \-\-nsamples ]
 .RB [ \-C1 ]
 .RB [ \-c
 .IR result_count ]
@@ -481,7 +480,7 @@ For boolean problems, this is the same as flipping the output
 value.  This option can only be used once, and, if used, it should
 specify a column containing an integer or floating-point value.
 .TP
-.BI \-b\  num \fR,\ \fB\-\-nsamples= num
+.BI \-\-nsamples= num
 The number of samples to be taken from the input file. Valid values
 run between 1 and the number of rows in the data file; other values
 are ignored. If this option is absent, then all data rows are used.
@@ -1249,7 +1248,7 @@ combo program specified with the \fB-y\fR flag. That is, the goal of
 the run is to deduce and learn the specified combo program.
 
 When specifying combo programs with continuous variables in them, be
-sure to use the \fB\-q\fR, \fB\-w\fR and \fB\-b\fR flags to specify
+sure to use \fB\-q\fR, \fB\-w\fR and \fB\-\-nsample\fR to specify
 a range of input values to be sampled. In order to determine the fitness
 of any candidate, it must be compared to the specified combo
 program.  The comparison is done at a variety of different input


### PR DESCRIPTION
...while it had nothing to do with that, rather it was a shorthand for `--nsamples`. Since such option is rarely used it's better to remove the shorthand.