### PR TITLE
Increasing the complexity pressure speeds up AntUTest

### DIFF
--- a/tests/moses/AntUTest.cxxtest
+++ b/tests/moses/AntUTest.cxxtest
@@ -80,7 +80,7 @@ public:
         ant_bscore bscorer;
 
         // See the diary for the complexity ratio.
-        double complexity_ratio = 0.16;
+        double complexity_ratio = 0.08;
         bscorer.set_complexity_coef(complexity_ratio);
         behave_cscore cscorer(bscorer);
 


### PR DESCRIPTION
10x across most random seeds.