### PR TITLE
Fix clang compile error

### DIFF
--- a/moses/comboreduct/combo/vertex.h
+++ b/moses/comboreduct/combo/vertex.h
@@ -147,6 +147,7 @@ typedef vertex_set::const_iterator vertex_set_const_it;
 typedef std::vector<vertex> vertex_seq;
 typedef vertex_seq::iterator vertex_seq_it;
 typedef vertex_seq::const_iterator vertex_seq_const_it;
+static const vertex_seq empty_vertex_seq = vertex_seq();
 
 typedef std::set<vertex> operator_set;
 typedef operator_set::iterator operator_set_it;

--- a/moses/comboreduct/interpreter/interpreter.cc
+++ b/moses/comboreduct/interpreter/interpreter.cc
@@ -234,14 +234,14 @@ mixed_interpreter::mixed_interpreter(const std::vector<contin_t>& inputs) :
     contin_interpreter(inputs),
     _use_boolean_inputs(false),
     _use_contin_inputs(true),
-    _mixed_inputs(std::vector<vertex>())
+    _mixed_inputs(empty_vertex_seq)
 {}
 
 mixed_interpreter::mixed_interpreter(const std::vector<builtin>& inputs) :
     boolean_interpreter(inputs),
     _use_boolean_inputs(true),
     _use_contin_inputs(false),
-    _mixed_inputs(std::vector<vertex>())
+    _mixed_inputs(empty_vertex_seq)
 {}
 
 vertex mixed_interpreter::operator()(const combo_tree& tr) const

--- a/moses/comboreduct/interpreter/interpreter.h
+++ b/moses/comboreduct/interpreter/interpreter.h
@@ -79,7 +79,7 @@ protected:
 struct mixed_interpreter : public boolean_interpreter, public contin_interpreter
 {
     // ctor
-    mixed_interpreter(const std::vector<vertex>& inputs = std::vector<vertex>());
+    mixed_interpreter(const std::vector<vertex>& inputs=empty_vertex_seq);
     mixed_interpreter(const std::vector<contin_t>& inputs);
     mixed_interpreter(const std::vector<builtin>& inputs);
 

--- a/moses/moses/deme/feature_selector.h
+++ b/moses/moses/deme/feature_selector.h
@@ -195,7 +195,7 @@ struct feature_selector
     // Parameters
     feature_selector_parameters params;
 
-    const combo::CTable& _ctable;
+    const combo::CTable _ctable;
 protected:
     /// Overwrite some parameters
     void preprocess_params(const combo::combo_tree& xmplr);


### PR DESCRIPTION
Indeed, this only works for const references on the stack, not as
class members, as explained here

https://herbsutter.com/2008/01/01/gotw-88-a-candidate-for-the-most-important-const/

meaning clang is actually correct here, not gcc.